### PR TITLE
Make work with stricter compilation flags

### DIFF
--- a/demos/demo1.cpp
+++ b/demos/demo1.cpp
@@ -41,7 +41,7 @@ public:
         connect( reply, SIGNAL(finished()), SLOT(onGotSimilar()) );
     }
     
-private slots:
+private Q_SLOTS:
     void onGotSimilar()
     {
         QNetworkReply* r = static_cast<QNetworkReply*>(sender());

--- a/demos/demo2.cpp
+++ b/demos/demo2.cpp
@@ -20,7 +20,7 @@ public:
     MyCoreApp( int& argc, char**& argv ) : QCoreApplication( argc, argv )
     {}
     
-private slots:
+private Q_SLOTS:
     void onWsError( lastfm::ws::Error e )
     {
         // QNetworkReply will invoke this slot on application level errors

--- a/demos/demo3.cpp
+++ b/demos/demo3.cpp
@@ -21,7 +21,7 @@ public:
     MyCoreApp( int& argc, char** argv ) : QCoreApplication( argc, argv )
     {}
 
-public slots:
+public Q_SLOTS:
     void onStatus( int status )
     {
         qDebug() << lastfm::Audioscrobbler::Status(status);

--- a/src/Album.h
+++ b/src/Album.h
@@ -57,8 +57,8 @@ namespace lastfm
         bool isNull() const;
     
         /** Album.getInfo WebService */
-        QNetworkReply* getInfo( const QString& username = "" ) const;
-        QNetworkReply* share( const QStringList& recipients, const QString& message = "", bool isPublic = true ) const;
+        QNetworkReply* getInfo( const QString& username = QStringLiteral("") ) const;
+        QNetworkReply* share( const QStringList& recipients, const QString& message = QStringLiteral(""), bool isPublic = true ) const;
 
         /** use Tag::list to get the tag list out of the finished reply */
         QNetworkReply* getTags() const;

--- a/src/Artist.h
+++ b/src/Artist.h
@@ -67,10 +67,10 @@ namespace lastfm
 
         QDomElement toDomElement( QDomDocument& ) const;
 
-        QNetworkReply* share( const QStringList& recipients, const QString& message = "", bool isPublic = true ) const;
+        QNetworkReply* share( const QStringList& recipients, const QString& message = QStringLiteral(""), bool isPublic = true ) const;
 
         QNetworkReply* getEvents(int limit = 0) const;
-        QNetworkReply* getInfo( const QString& username = "" ) const;
+        QNetworkReply* getInfo( const QString& username = QStringLiteral("") ) const;
         static Artist getInfo( QNetworkReply* );
 
         QNetworkReply* getSimilar( int limit = -1 ) const;

--- a/src/Audioscrobbler.h
+++ b/src/Audioscrobbler.h
@@ -43,14 +43,14 @@ namespace lastfm
         Audioscrobbler( const QString& clientId );
         ~Audioscrobbler();
 
-    signals:
+    Q_SIGNALS:
         void scrobblesCached( const QList<lastfm::Track>& tracks );
         /* Note that this is emitted after we tried to submit the scrobbles
         It could just be that they have an error code */
         void scrobblesSubmitted( const QList<lastfm::Track>& tracks );
         void nowPlayingError( int code, QString message );
 
-    public slots:
+    public Q_SLOTS:
         /** will ask Last.fm to update the now playing information for the 
           * authenticated user */
         void nowPlaying( const Track& );
@@ -62,7 +62,7 @@ namespace lastfm
         /** will submit the submission cache for this user */
         void submit();
 
-    private slots:
+    private Q_SLOTS:
         void onNowPlayingReturn();
         void onTrackScrobbleReturn();
 

--- a/src/InternetConnectionMonitor.h
+++ b/src/InternetConnectionMonitor.h
@@ -45,7 +45,7 @@ public:
 
     NetworkConnectionMonitor* createNetworkConnectionMonitor();
 
-signals:
+Q_SIGNALS:
     /** yay! internet has returned */
     void up( const QString& connectionName = "" );
     
@@ -56,7 +56,7 @@ signals:
     /** emitted after the above */
     void connectivityChanged( bool );
 
-private slots:
+private Q_SLOTS:
     void onFinished( QNetworkReply* reply );
     void onNetworkUp();
     void onNetworkDown();

--- a/src/Mbid.h
+++ b/src/Mbid.h
@@ -27,7 +27,7 @@ namespace lastfm
     class LASTFM_DLLEXPORT Mbid
     {
     public:
-        explicit Mbid( const QString& p = "" );
+        explicit Mbid( const QString& p = QStringLiteral("") );
         Mbid( const Mbid& that );
         ~Mbid();
 

--- a/src/NetworkAccessManager.h
+++ b/src/NetworkAccessManager.h
@@ -53,7 +53,7 @@ public:
 protected:
     virtual QNetworkReply* createRequest( Operation, const QNetworkRequest&, QIODevice* outgoingdata = 0 );
 
-private slots:
+private Q_SLOTS:
     void onConnectivityChanged( bool );
 
 private:

--- a/src/NetworkConnectionMonitor.h
+++ b/src/NetworkConnectionMonitor.h
@@ -35,7 +35,7 @@ public:
     ~NetworkConnectionMonitor();
     bool isConnected() const;
 
-signals:
+Q_SIGNALS:
     void networkUp();
     void networkDown();
 

--- a/src/RadioTuner.cpp
+++ b/src/RadioTuner.cpp
@@ -65,7 +65,7 @@ class lastfm::RadioTunerPrivate : public QObject
           */
         void fetchFiveMoreTracks();
 
-    private slots:
+    private Q_SLOTS:
         void onTwoSecondTimeout();
 };
 

--- a/src/RadioTuner.h
+++ b/src/RadioTuner.h
@@ -48,13 +48,13 @@ namespace lastfm
 
         void queueTrack( lastfm::Track& track );
 
-    signals:
+    Q_SIGNALS:
         void title( const QString& );
         void supportsDisco( bool supportsDisco );
         void trackAvailable();
         void error( lastfm::ws::Error, const QString& message );
 
-    private slots:
+    private Q_SLOTS:
         void onTuneReturn();
         void onGetPlaylistReturn();
         // no-op

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -112,12 +112,12 @@ public:
     void forceScrobbleStatusChanged();
     void forceCorrected( QString correction );
 
-private slots:
+private Q_SLOTS:
     void onLoveFinished();
     void onUnloveFinished();
     void onGotInfo();
 
-signals:
+Q_SIGNALS:
     void loveToggled( bool love );
     void scrobbleStatusChanged( short scrobbleStatus );
     void corrected( QString correction );

--- a/src/Track.h
+++ b/src/Track.h
@@ -193,7 +193,7 @@ public:
 //////////// lastfm::Ws
     
     /** See last.fm/api Track section */
-    QNetworkReply* share( const QStringList& recipients, const QString& message = "", bool isPublic = true ) const;
+    QNetworkReply* share( const QStringList& recipients, const QString& message = QStringLiteral(""), bool isPublic = true ) const;
 
     QNetworkReply* getSimilar( int limit = -1 ) const;
     /** The match percentage is returned from last.fm as a 4 significant
@@ -211,7 +211,7 @@ public:
     /** method should be a method name of reciever that takes a QByteArray
     If that fails it will try invoking method with no arguments.
     */
-    void getInfo( QObject* receiver, const char * method, const QString& username = "" ) const;
+    void getInfo( QObject* receiver, const char * method, const QString& username = QStringLiteral("") ) const;
     QNetworkReply* getBuyLinks( const QString& country ) const;
 
     static QNetworkReply* playlinks( const QList<Track>& tracks );

--- a/src/User.h
+++ b/src/User.h
@@ -121,7 +121,7 @@ namespace lastfm
     
         QNetworkReply* getLovedTracks( int limit = 50, int page = 1 ) const;
         QNetworkReply* getPlaylists() const;
-        QNetworkReply* getTopArtists( QString period = "overall", int limit = 50, int page = 1 ) const;
+        QNetworkReply* getTopArtists( QString period = QStringLiteral("overall"), int limit = 50, int page = 1 ) const;
         QNetworkReply* getRecentTracks( int limit = 50, int page = 1 ) const;
         QNetworkReply* getRecentArtists() const;
         QNetworkReply* getRecentStations(  int limit = 10, int page = 1  ) const;

--- a/src/Xspf.h
+++ b/src/Xspf.h
@@ -40,10 +40,10 @@ namespace lastfm
 
         QList<Track> tracks() const;
 
-    signals:
+    Q_SIGNALS:
         Q_DECL_DEPRECATED void expired();
 
-    private slots:
+    private Q_SLOTS:
         Q_DECL_DEPRECATED void onExpired();
 
     private:

--- a/src/global.h.in
+++ b/src/global.h.in
@@ -62,7 +62,7 @@ namespace lastfm
         for (int i=0; i < meta.enumeratorCount(); ++i)
         {
             QMetaEnum m = meta.enumerator(i);
-            if (m.name() == QLatin1String(enum_name))
+            if (QLatin1String(m.name()) == QLatin1String(enum_name))
                 return QLatin1String(m.valueToKey(enum_value));
         }
         return QString("Unknown enum value for \"%1\": %2").arg( enum_name ).arg( enum_value );

--- a/src/linux/LNetworkConnectionMonitor.h
+++ b/src/linux/LNetworkConnectionMonitor.h
@@ -49,7 +49,7 @@ class LNetworkConnectionMonitor : public NetworkConnectionMonitor
 public:
     LNetworkConnectionMonitor( QObject* parent = 0 );
     ~LNetworkConnectionMonitor();
-private slots:
+private Q_SLOTS:
     void onStateChange( uint newState );
 private:
     QDBusInterface* m_nmInterface;

--- a/src/mac/MNetworkConnectionMonitor.h
+++ b/src/mac/MNetworkConnectionMonitor.h
@@ -39,7 +39,7 @@ class MNetworkConnectionMonitor : public NetworkConnectionMonitor
 public:
     MNetworkConnectionMonitor( QObject* parent = 0 );
     ~MNetworkConnectionMonitor();
-private slots:
+private Q_SLOTS:
 
 private:
 #ifdef Q_OS_MAC

--- a/tests/TestTrack.h
+++ b/tests/TestTrack.h
@@ -26,7 +26,7 @@ class TestTrack : public QObject
         return t;
     }
     
-private slots:
+private Q_SLOTS:
     void testClone()
     {
         Track original = example();

--- a/tests/TestUrlBuilder.h
+++ b/tests/TestUrlBuilder.h
@@ -37,7 +37,7 @@ class TestUrlBuilder : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void encode() /** @author <jono@last.fm> */
     {
         QFETCH( QString, input );


### PR DESCRIPTION
QT_NO_CAST_[FROM/TO]_ASCII and signals -> Q_SIGNALS, slots -> Q_SLOTS

Needed e.g. when included in default settings compilation of KDE Frameworks 5.85+ software.