### PR TITLE
Fix use-after-free in platform()-calling code

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -163,11 +163,11 @@ lastfm::CFStringToUtf8( CFStringRef s )
 #endif
 
 
-const char*
+QByteArray
 lastfm::platform()
 {
-    static QString platform = QSysInfo::prettyProductName();
-    return qPrintable(platform);
+    static const auto platform = QSysInfo::prettyProductName().toUtf8();
+    return platform;
 }
 
 QString lastfm::

--- a/src/misc.h
+++ b/src/misc.h
@@ -47,7 +47,7 @@ namespace lastfm
     LASTFM_DLLEXPORT CFStringRef QStringToCFString( const QString& );
     LASTFM_DLLEXPORT QString CFStringToQString( CFStringRef s );
 #endif
-    LASTFM_DLLEXPORT const char* platform();
+    LASTFM_DLLEXPORT QByteArray platform();
     LASTFM_DLLEXPORT QString md5( const QByteArray& src );
 }
 #endif //LASTFM_MISC_H


### PR DESCRIPTION
As per Qt docs, the return value of `qPrintable()` is only valid until the end of the expression.

In fact, asan did catch this in the calling code:
```
==6370==ERROR: AddressSanitizer: heap-use-after-free on address 0x5060019d5290 at pc 0x55eac94942ec bp 0x7ffe2a558b10 sp 0x7ffe2a5582d8
READ of size 13 at 0x5060019d5290 thread T0
    #0 0x55eac94942eb in strlen (/usr/local/bin/leechcraft-qt6+0x9a2eb)
    #1 0x7f9e89500602 in lastfm::NetworkAccessManager::NetworkAccessManager(QObject*) (/usr/lib64/liblastfm6.so.1+0x2a602)
    #2 0x7f9e894fd896 in lastfm::nam() (/usr/lib64/liblastfm6.so.1+0x27896)
    #3 0x7f9e894fe04f in lastfm::ws::post(QMap<QString, QString>, bool) (/usr/lib64/liblastfm6.so.1+0x2804f)
    #4 0x7f9e89513422 in lastfm::Track::updateNowPlaying(int) const (/usr/lib64/liblastfm6.so.1+0x3d422)
    #5 0x7f9e8952a877 in lastfm::Audioscrobbler::nowPlaying(lastfm::Track const&) (/usr/lib64/liblastfm6.so.1+0x54877)
    ...

0x5060019d5290 is located 16 bytes inside of 57-byte region [0x5060019d5280,0x5060019d52b9)
freed by thread T0 here:
    #0 0x55eac9686586 in free (/usr/local/bin/leechcraft-qt6+0x28c586)
    #1 0x7f9e8953a228 in lastfm::platform() (/usr/lib64/liblastfm6.so.1+0x64228)
```